### PR TITLE
chore(deps): align tedilabs child module version constraints with latest releases

### DIFF
--- a/examples/quicksight-assets/main.tf
+++ b/examples/quicksight-assets/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "folder__dev" {
   source = "../../modules/folder"
   # source  = "tedilabs/quicksight/aws//modules/folder"
-  # version = "~> 0.5.0"
+  # version = "~> 0.3.0"
 
   name          = "dev"
   display_name  = "Dev Folder"
@@ -32,7 +32,7 @@ module "folder__dev" {
 module "folder__test" {
   source = "../../modules/folder"
   # source  = "tedilabs/quicksight/aws//modules/folder"
-  # version = "~> 0.5.0"
+  # version = "~> 0.3.0"
 
   name          = "test"
   display_name  = "Test Folder"

--- a/modules/vpc-connection/security-groups.tf
+++ b/modules/vpc-connection/security-groups.tf
@@ -13,7 +13,7 @@ locals {
 # TODO: support `region`
 module "security_group" {
   source  = "tedilabs/network/aws//modules/security-group"
-  version = "~> 1.0.0"
+  version = "~> 1.2.0"
 
   count = var.default_security_group.enabled ? 1 : 0
 


### PR DESCRIPTION
## What & why

The `version` constraint on `tedilabs/network/aws//modules/security-group` in `modules/vpc-connection` had drifted behind that module's latest release — pinned to the `1.0.x` line while the latest is v1.2.3. This PR realigns it to the house `~> MAJOR.MINOR.0` minor-floor convention so it resolves to the newest patch in the current minor line.

It also corrects the commented-out registry `# version` lines in `examples/quicksight-assets/main.tf`, which advertised a version of this repo's own `modules/folder` that has never existed. See the note below — that one moves *down*, deliberately.

## Changed constraints

### Active module blocks

| Child module | Path | Before | After | Latest release |
|---|---|---|---|---|
| `tedilabs/network/aws//modules/security-group` | `modules/vpc-connection/security-groups.tf` | `~> 1.0.0` | `~> 1.2.0` | v1.2.3 |

### Example docs (commented)

These are commented-out registry alternatives; the active `source` in the example is the local `../../modules/folder` path, so nothing resolvable changes. They are documentation for consumers.

| Child module | Path | Before | After | Latest release |
|---|---|---|---|---|
| `tedilabs/quicksight/aws//modules/folder` (self) | `examples/quicksight-assets/main.tf` (module `folder__dev`) | `~> 0.5.0` | `~> 0.3.0` | v0.3.0 |
| `tedilabs/quicksight/aws//modules/folder` (self) | `examples/quicksight-assets/main.tf` (module `folder__test`) | `~> 0.5.0` | `~> 0.3.0` | v0.3.0 |

### Why the example constraint moves *down* — this is not a mistake

A version constraint going backwards looks like an error, so to be explicit: **`~> 0.5.0` never pointed at a real `tedilabs/quicksight/aws` release.** It was copied verbatim from another repo's version series.

This repository was split out of `tedilabs/terraform-aws-data` — its very first commit is `f90f314 feat: copied from tedilabs/terraform-aws-data`. The example files came across with that copy, `# version` lines and all, still carrying the `0.5.x` constraint from the *source* repo's numbering. `terraform-aws-quicksight` then started its own version series from v0.1.0.

The full tag list for this repo is:

```
$ git tag --sort=-v:refname
v0.3.0
v0.2.0
v0.1.0
```

So `~> 0.5.0` (`>= 0.5.0, < 0.6.0`) matches **nothing** — a consumer who uncommented those lines would get a "no available releases match the given constraints" error from `terraform init`. `~> 0.3.0` is the correct minor floor for the newest actual release, and `modules/folder` does exist at that tag (verified: `git ls-tree --name-only v0.3.0:modules/` lists `account`, `data-set`, `data-source`, `folder`, `group`, `namespace`, `user`, `vpc-connection`).

## Interface changes between the old and new versions

### `tedilabs/network/aws//modules/security-group` — v1.0.2 → v1.2.3

Compare: https://github.com/tedilabs/terraform-aws-network/compare/v1.0.2...v1.2.3

**Verdict: BACKWARD_COMPATIBLE. No calling code changed.**

- **Added variables:** none.
- **Removed variables:** none.
- **Retyped variables:** one, and it is a pure relaxation — `from_port` and `to_port` inside the `ingress_rules` / `egress_rules` element objects went from required `number` to `optional(number)`. Every value shape valid at v1.0.2 is still valid at v1.2.3.
- **Outputs:** none added, removed, or renamed.
- **Version floors:** unchanged — `required_version = ">= 1.12"`, `hashicorp/aws >= 6.12` at both tags. No new floor, so this repo's `versions.tf` needs no edit.

One observation, deliberately left alone in this PR: this repo's own `var.default_security_group.ingress_rules` / `.egress_rules` wrapper (in `modules/vpc-connection/variables.tf`) still declares `from_port = number` and `to_port = number` as **required**. That is stricter than the child module now requires, so the upstream relaxation is not passed through to this module's consumers. Nothing breaks — a stricter wrapper over a relaxed dependency is always safe — but relaxing it to `optional(number)` would be needed to let callers express `protocol = "-1"` rules without dummy ports. That is a behaviour change to this module's public interface, out of scope for a dependency-constraint PR, and worth its own change if wanted.

One operational note that does **not** apply here: between v1.0.2 and v1.2.3, the security-group module's *internal* RAM share changed `resources` from a list to a map keyed by `var.name`, and now sanitises the share name through `replace(var.name, "/[^a-zA-Z0-9_\\.-]/", "-")`. That only produces plan churn for callers that pass `shares`. **This repo's call site does not set `shares`** (`grep -rn shares modules/vpc-connection/` returns nothing), and `shares` defaults to `[]`, leaving `module.share` with zero instances. So there is no RAM-share churn from this bump.

## Verification

- `terraform fmt -recursive -check .` — passes.
- `terraform init -backend=false` + `terraform validate` in `modules/vpc-connection` — `Success! The configuration is valid.`
- The new constraint was confirmed to resolve against the real registry. From `.terraform/modules/modules.json` after init: `security_group` → **1.2.3** (`~> 1.2.0`).
- All `.terraform/` directories and `.terraform.lock.hcl` files created during verification were removed before committing; `git status --porcelain` shows only the two intended files.

Not verified: no `terraform plan` or `apply` was run, so this PR does not prove an empty plan against live infrastructure — that needs AWS credentials and real state. Based on the interface analysis above, an empty plan is expected. The `examples/quicksight-assets` edits touch only comments, so they are unverifiable by tooling by construction; the example's active `source` remains the local module path. I did not attempt to `init` the commented registry constraint to prove `~> 0.3.0` resolves, since `modules/folder`'s presence at v0.3.0 was confirmed directly from the git tag instead.

## Supersedes

One open dependabot PR covers the same constraint:

| PR | Constraint it proposes | Path |
|---|---|---|
| #26 | `tedilabs/network/aws` `~> 1.0.0` → `~> 1.2.2` | `/modules/vpc-connection` |

This PR supersedes #26 because dependabot pins the exact patch (`~> 1.2.2`) rather than the house minor floor (`~> 1.2.0`). The pinned form would need a fresh PR for every 1.2.x patch — and is already behind, since v1.2.3 has shipped. `~> 1.2.0` resolves to v1.2.3 today and absorbs future 1.2.x patches without churn. #26 also does not touch the commented registry examples under `examples/`, which dependabot does not parse.

Leaving #26 open — not closing it here.
