### PR TITLE
docs(readme): align example module versions with the latest release

### DIFF
--- a/modules/data-source/README.md
+++ b/modules/data-source/README.md
@@ -43,7 +43,7 @@ parameters = {
 
 ```hcl
 parameters = {
-  work_group = "primary"              # Optional, defaults to "primary"
+  workgroup = "primary"               # Optional, defaults to "primary"
 }
 ```
 
@@ -64,7 +64,8 @@ parameters = {
 
 ```hcl
 module "aurora_postgresql_data_source" {
-  source = "tedilabs/quicksight/aws//modules/data-source"
+  source  = "tedilabs/quicksight/aws//modules/data-source"
+  version = "~> 0.3.0"
 
   name         = "aurora-postgresql-ds"
   display_name = "Aurora PostgreSQL Data Source"
@@ -87,14 +88,15 @@ module "aurora_postgresql_data_source" {
 
 ```hcl
 module "athena_data_source" {
-  source = "tedilabs/quicksight/aws//modules/data-source"
+  source  = "tedilabs/quicksight/aws//modules/data-source"
+  version = "~> 0.3.0"
 
   name         = "athena-ds"
   display_name = "Athena Data Source"
   type         = "ATHENA"
 
   parameters = {
-    work_group = "analytics-workgroup"
+    workgroup = "analytics-workgroup"
   }
 
   # Athena typically doesn't require credentials
@@ -106,7 +108,8 @@ module "athena_data_source" {
 
 ```hcl
 module "s3_data_source" {
-  source = "tedilabs/quicksight/aws//modules/data-source"
+  source  = "tedilabs/quicksight/aws//modules/data-source"
+  version = "~> 0.3.0"
 
   name         = "s3-ds"
   display_name = "S3 Data Source"


### PR DESCRIPTION
## What & why

`modules/data-source/README.md` contains three hand-written, copy-paste HCL examples that reference
this repo's own module by its registry address. All three had **no `version` argument at all**, so a
copy-paste of them silently tracks whatever the newest release happens to be — precisely what the
house `version = "~> MAJOR.MINOR.0"` convention exists to prevent. This PR pins all three to the
current release and fixes one genuinely wrong argument name found while checking the examples
against the module's interface.

Target version resolved from the repo's newest tag: **v0.3.0** (`git tag --sort=-v:refname | head -1`;
`VERSION` also reads `0.3.0`). `modules/data-source` exists at that tag.

Docs-only: one `*.md` file. No `*.tf` touched.

## Changed examples

| Example block | Module | Before | After |
|---|---|---|---|
| `module "aurora_postgresql_data_source"` (Aurora PostgreSQL) | `tedilabs/quicksight/aws//modules/data-source` | _(no `version`)_ | `~> 0.3.0` |
| `module "athena_data_source"` (Athena) | `tedilabs/quicksight/aws//modules/data-source` | _(no `version`)_ | `~> 0.3.0` |
| `module "s3_data_source"` (S3) | `tedilabs/quicksight/aws//modules/data-source` | _(no `version`)_ | `~> 0.3.0` |

The `source` lines were re-spaced to `source  = ` so the `source`/`version` pair aligns on the `=`,
matching house style. These are fenced markdown code blocks, so `terraform fmt` does not reach them —
alignment was done by hand.

## Interface check against `modules/data-source` at v0.3.0

There is no older pinned version to diff from (the examples were never pinned), so instead of a
version-to-version diff I checked every argument of each of the three blocks against
`modules/data-source/variables.tf` and `main.tf` at v0.3.0. The three blocks exercise different
branches of the `parameters` surface (database / Athena / S3), so each was checked independently.

### One real bug found: Athena `work_group` -> `workgroup`

The module reads the Athena workgroup from `parameters.workgroup`:

```hcl
# modules/data-source/main.tf
dynamic "athena" {
  ...
  content {
    work_group = coalesce(lookup(athena.value, "workgroup", "primary"), "primary")
  }
}
```

`work_group` is the *provider* attribute name; the *module input* key is `workgroup`, as
`variables.tf` and the generated Inputs table both document. Because `parameters` is typed `any` and
read with `lookup(..., "workgroup", "primary")`, passing `work_group` does not error — it is silently
ignored and the workgroup falls back to `primary`. A user copy-pasting this example would get the
default workgroup while believing they had selected their own. Fixed in the Athena example and in the
matching `## Parameter Schemas by Data Source Type` snippet above it (same defect, two places — happy
to drop the snippet hunk if you'd rather keep this PR to the three module blocks):

```diff
 parameters = {
-  work_group = "analytics-workgroup"
+  workgroup = "analytics-workgroup"
 }
```

### Everything else checked out

- **Required variables** — `name`, `type`, `parameters` are the only required inputs; all three blocks
  pass all three.
- **Non-existent / renamed arguments** — none. Every argument used (`name`, `display_name`, `type`,
  `parameters`, `credentials`) exists at v0.3.0. No flat-to-object collapse affects these blocks;
  `credentials`, `ssl`, `vpc_connection`, `resource_group` are already object-shaped and the examples
  either match or omit them.
- **Object attributes** — the Aurora block's `credentials = { type, secrets_manager_secret }` matches
  the `credentials` object type exactly and satisfies its "SECRETS_MANAGER requires
  `secrets_manager_secret`" validation.
- **`parameters` validations** — Aurora's `port = 5432` is in `1..65535`; S3's
  `manifest_file_location` starts with `s3://` and has a key component (the module parses it with
  `regex("^s3://([^/]+)/(.*)$")`); S3's `iam_role` parses as an IAM ARN via
  `provider::aws::arn_parse`.
- **Outputs** — none of the three examples reference module outputs, so there is nothing to break
  there.

No compare URL applies (nothing to compare from). For reference, `modules/data-source` is byte-identical
between v0.3.0 and `main`: `git diff v0.3.0 origin/main -- modules/data-source/` is empty.

## Verification

- `git diff v0.3.0 origin/main -- modules/` shows drift in **only** `modules/vpc-connection`
  (`iam.tf`, `variables.tf` — the `permissions_boundary` addition in #29). `modules/data-source` has
  zero drift, so `modules/data-source` at `main` **is** the v0.3.0 release, which makes validating
  against a relative in-repo path a faithful proxy for the released module. These examples do not
  reference `vpc-connection`, so that drift is irrelevant here.
- Scratch roots outside the repo (never committed): each example block copied into a `main.tf` with
  `source` repointed at `./modules/data-source` by relative path, plus a `versions.tf` satisfying the
  module's floors (`terraform >= 1.12`, `aws >= 6.12`), then `terraform init -backend=false` +
  `terraform validate` with a private `TF_PLUGIN_CACHE_DIR`. No `plan`, no `apply`.
- I validated the example **bodies** against the local module. The registry **address** itself is not
  resolvable — see the caveat below — so `terraform init` on the examples exactly as written in the
  README is not possible for anyone, and that is not something this PR can fix.

### Results

| Block | Result |
|---|---|
| Aurora PostgreSQL | `Success! The configuration is valid.` |
| Athena | fails — but on a pre-existing module bug, not on the example (below) |
| S3 | fails — same pre-existing module bug |

**Pre-existing module bug in `credentials` validation (not introduced or fixed here).** The Athena and
S3 examples pass `credentials = null`, which is legitimate and matches the variable's own default. It
fails `terraform validate` with 9 x `Attempt to get attribute from null value` inside
`modules/data-source/variables.tf` (lines 117-118, 125-126, 133-134). The three validation blocks are
shaped like:

```hcl
condition = anytrue([
  var.credentials == null,
  var.credentials.type != "CREDENTIAL_PAIR",
  var.credentials.type == "CREDENTIAL_PAIR" && var.credentials.credential_pair != null,
])
```

`anytrue` evaluates every list element — there is no short-circuit — so `var.credentials.type` is
evaluated even when `var.credentials` is null. I confirmed this is a module bug and not an example
bug by testing both spellings: `credentials = null` **and omitting `credentials` entirely** produce
the identical 9 errors, i.e. the module cannot be used at all without a non-null `credentials` value,
including in the S3 case its own docs call out as not needing credentials. The fix belongs in
`variables.tf` (e.g. `var.credentials == null ? true : anytrue([...])`, or `try(...)` /
`coalesce(...)` guards), which is out of scope for a docs-only PR — flagging it rather than silently
working around it by editing the examples. Worth a follow-up issue.

## Material caveat: this module is not published to the Terraform Registry

`tedilabs/quicksight/aws` is **not** on the public Terraform Registry. Verified two ways: a registry
version lookup for `tedilabs/quicksight/aws` returns **404 Not Found**, and
`https://registry.terraform.io/v1/modules/tedilabs/quicksight/aws` returns **HTTP 404**. It is also
absent from the `namespace=tedilabs` module listing (29 modules, `quicksight` not among them) — even
though GitHub has a v0.3.0 release.

Consequence, stated plainly: **these README examples cannot be `terraform init`-ed as written, with or
without a version pin, because the source address does not resolve.** This PR does not make the
examples work. Adding the pin is still the right change — it matches the house convention and becomes
correct the moment the module is published — but the actual blocker for these examples being usable is
**publishing `terraform-aws-quicksight` to the registry**. Until then a user must consume the module
by git source or vendored path, neither of which these examples show.

## Relationship to the other open PR

#30 `chore(deps): align tedilabs child module version constraints with latest releases` covers the
`*.tf` side of this repo (one `tedilabs/network/aws//modules/security-group` bump, plus two commented
example lines moved *down* from `~> 0.5.0` to `~> 0.3.0` — this repo was split out of
`terraform-aws-data` and inherited that repo's version series). This PR is the docs-only counterpart:
it touches exactly one file, `modules/data-source/README.md`, which #30 does not touch. The two are on
separate branches and edit disjoint files, so they will not conflict and can merge in either order.
