### PR TITLE
fix(examples): correct terraform and provider version constraints

### DIFF
--- a/examples/quicksight-assets/versions.tf
+++ b/examples/quicksight-assets/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/quicksight-user-and-group/versions.tf
+++ b/examples/quicksight-user-and-group/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
## What & why

Both example roots pin `hashicorp/aws = "~> 4.0"`, an upper bound of `< 5.0.0`, while every local
module in this repo declares `>= 6.12`. The intersection is empty, so `terraform init` cannot resolve
a provider and the examples are unusable.

Reproduced verbatim in `examples/quicksight-assets` before the fix:

```
Initializing provider plugins found in the configuration...
- Finding hashicorp/aws versions matching "~> 4.0, >= 6.0.0, >= 6.12.0"...
╷
│ Error: Failed to query available provider packages
│
│ Could not retrieve the list of available versions for provider
│ hashicorp/aws: no available releases match the given constraints ~> 4.0, >=
│ 6.0.0, >= 6.12.0
│
│ To see which modules are currently depending on hashicorp/aws and what
│ versions are specified, run the following command:
│     terraform providers
╵
```

## Convention applied

Repo convention, verified unanimous across the already-correct repos in this family:

- terraform: `required_version = "~> x.y"` → `~> 1.12`
- providers: `version = "~> x.0"` → `aws = "~> 6.0"`

`~> 6.0` is sufficient even though the modules declare `>= 6.12`: Terraform intersects every
constraint in the module graph, so `~> 6.0` ∩ `>= 6.12` = `[6.12, 7.0)`. Confirmed empirically — both
roots resolve `hashicorp/aws v6.58.0`. No minor floor is pinned into the roots.

## Changed roots

| Example root | `required_version` before → after | `aws` before → after | Why |
| --- | --- | --- | --- |
| `examples/quicksight-assets` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | conflict (`modules/folder` needs `>= 6.12`) |
| `examples/quicksight-user-and-group` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | conflict (`modules/namespace`, `modules/group` need `>= 6.12`) |

Both roots had an init-breaking conflict; 0 were style-only.

## Verification

`terraform fmt -recursive -check .` — passes.

Per root, with a private `TF_PLUGIN_CACHE_DIR`, run serially:

| Example root | Result |
| --- | --- |
| `examples/quicksight-assets` | `init` OK, `validate` OK (`Success! The configuration is valid.`) |
| `examples/quicksight-user-and-group` | `init` OK, `validate` OK (`Success! The configuration is valid.`) |

Both changed roots now init and validate cleanly on `hashicorp/aws v6.58.0`.

## Pre-existing failures newly exposed

None. Fixing provider resolution exposed no latent `validate` errors — both roots pass
`terraform validate`.

For the record, one unrelated pre-existing bug does exist in this repo but is **not** reachable from
either example root, so this PR neither exposes nor fixes it: the validation blocks in
`modules/data-source/variables.tf` are written as
`anytrue([var.credentials == null, var.credentials.type != ...])`. `anytrue` does not short-circuit,
so passing `credentials = null` or omitting `credentials` fails with
`Attempt to get attribute from null value`. Neither `examples/quicksight-assets` nor
`examples/quicksight-user-and-group` instantiates `modules/data-source` (they use `modules/folder`,
`modules/namespace`, `modules/group`), so it stays latent. Noted here only so it can be tracked
separately.

## Related PRs

Open PRs in this repo; file sets are disjoint from this one.

- #30 `chore(deps): align tedilabs child module version constraints with latest releases` — touches
  `examples/quicksight-assets/main.tf` and `modules/vpc-connection/security-groups.tf`, not any
  `versions.tf`.
- #31 `docs(readme): align example module versions with the latest release` — touches
  `modules/data-source/README.md` only.
- #26 `chore(deps): update tedilabs/network/aws requirement from ~> 1.0.0 to ~> 1.2.2 in
  /modules/vpc-connection` (dependabot, `modules/vpc-connection` only).

This PR touches only the 2 `examples/*/versions.tf` files listed above.
