### PR TITLE
fix(data-source): guard credentials validations against a null value

### DIFF
--- a/modules/data-source/variables.tf
+++ b/modules/data-source/variables.tf
@@ -112,27 +112,24 @@ variable "credentials" {
   sensitive = true
 
   validation {
-    condition = anytrue([
-      var.credentials == null,
-      var.credentials.type != "CREDENTIAL_PAIR",
-      var.credentials.type == "CREDENTIAL_PAIR" && var.credentials.credential_pair != null,
-    ])
+    condition = (var.credentials == null
+      ? true
+      : var.credentials.type != "CREDENTIAL_PAIR" || var.credentials.credential_pair != null
+    )
     error_message = "If `type` is set to `CREDENTIAL_PAIR`, then `credential_pair` must be provided."
   }
   validation {
-    condition = anytrue([
-      var.credentials == null,
-      var.credentials.type != "COPY_DATA_SOURCE",
-      var.credentials.type == "COPY_DATA_SOURCE" && var.credentials.data_source != null,
-    ])
+    condition = (var.credentials == null
+      ? true
+      : var.credentials.type != "COPY_DATA_SOURCE" || var.credentials.data_source != null
+    )
     error_message = "If `type` is set to `COPY_DATA_SOURCE`, then `data_source` must be provided."
   }
   validation {
-    condition = anytrue([
-      var.credentials == null,
-      var.credentials.type != "SECRETS_MANAGER",
-      var.credentials.type == "SECRETS_MANAGER" && var.credentials.secrets_manager_secret != null,
-    ])
+    condition = (var.credentials == null
+      ? true
+      : var.credentials.type != "SECRETS_MANAGER" || var.credentials.secrets_manager_secret != null
+    )
     error_message = "If `type` is set to `SECRETS_MANAGER`, then `secrets_manager_secret` must be provided."
   }
 }


### PR DESCRIPTION
## What & why

`modules/data-source` cannot be used without credentials. Its three `credentials` validation blocks
use `anytrue([var.credentials == null, var.credentials.type != …, …])`, and `anytrue` evaluates every
element of its list before deciding — it does not short-circuit — so the `var.credentials == null`
guard never protects the attribute accesses that follow it. Any caller that passes
`credentials = null` or omits `credentials` (its default is `null`) fails with `Attempt to get
attribute from null value`. That includes two of the module's own README examples (Athena and S3),
and the S3 case is exactly the one the README calls out as *"Not required for S3 data sources"*.

The fix replaces `anytrue([...])` with a `var.credentials == null ? true : <check>` conditional, which
does short-circuit. The intent of each rule is unchanged: only the null guard behaviour is corrected.

No example root instantiates `modules/data-source`, which is why this never showed up in CI — the bug
was latent. Everything else in the repo already passed; this PR is one file.

## Validation matrix

Every `modules/*` and `examples/*` dir, `terraform fmt -check` / `terraform init -backend=false` /
`terraform validate` (Terraform v1.15.6, hashicorp/aws 6.58.0).

| Dir | fmt before | init before | validate before | fmt after | init after | validate after |
|---|---|---|---|---|---|---|
| `modules/account` | pass | pass | pass | pass | pass | pass |
| `modules/data-set` | pass | pass | pass | pass | pass | pass |
| `modules/data-source` | pass | pass | pass* | pass | pass | pass |
| `modules/folder` | pass | pass | pass | pass | pass | pass |
| `modules/group` | pass | pass | pass | pass | pass | pass |
| `modules/namespace` | pass | pass | pass** | pass | pass | pass |
| `modules/user` | pass | pass | pass | pass | pass | pass |
| `modules/vpc-connection` | pass | pass | pass | pass | pass | pass |
| `examples/quicksight-assets` | pass | pass | pass | pass | pass | pass |
| `examples/quicksight-user-and-group` | pass | pass | pass | pass | pass | pass |

`terraform fmt -recursive -check .` at the repo root: clean before and after.

\* `terraform validate` inside `modules/data-source` itself passes **both** before and after — that is
the point. Terraform does not evaluate a root module's variable validation rules against their
defaults here, so the defect is invisible to a directory-level `validate` and only appears once
something actually *calls* the module. See "Reproduction" below.

\*\* `modules/namespace` produced `Failed to load plugin schemas … Failed to read any lines from
plugin's stdout` on the first audit pass. That is an environment/provider-launch flake on the machine
this ran on, not a config problem: three consecutive re-runs of the identical command in the identical
directory all returned `Success! The configuration is valid.` No code was changed in response to it.

## Changes

`modules/data-source/variables.tf`, all three `credentials` validation blocks.

Before (shown for the first rule; the `COPY_DATA_SOURCE` and `SECRETS_MANAGER` rules had the same
shape):

```tf
  validation {
    condition = anytrue([
      var.credentials == null,
      var.credentials.type != "CREDENTIAL_PAIR",
      var.credentials.type == "CREDENTIAL_PAIR" && var.credentials.credential_pair != null,
    ])
    error_message = "If `type` is set to `CREDENTIAL_PAIR`, then `credential_pair` must be provided."
  }
```

After:

```tf
  validation {
    condition = (var.credentials == null
      ? true
      : var.credentials.type != "CREDENTIAL_PAIR" || var.credentials.credential_pair != null
    )
    error_message = "If `type` is set to `CREDENTIAL_PAIR`, then `credential_pair` must be provided."
  }
```

Two things to note about the rewrite:

- `anytrue` takes a list, so every element is evaluated to build that list; putting the null check
  first buys nothing. `? :` and `||` are the short-circuiting forms.
- The two trailing elements of the old list collapse to a single `||`: `type != X` OR
  (`type == X` AND `y != null`) is just `type != X || y != null`.

For non-null `credentials` the accepted/rejected inputs are exactly the same as before.

## Reproduction

The module's own README examples were the reproduction. Each of the three HCL blocks in
`modules/data-source/README.md` was copied into a scratch root outside the repo with `source`
repointed at the in-repo module by relative path, plus a `versions.tf`, then `terraform init
-backend=false && terraform validate`:

| README block | against `main` | against this branch |
|---|---|---|
| Aurora PostgreSQL (`credentials = { type = "SECRETS_MANAGER", … }`) | pass | pass |
| Athena (`credentials = null`) | **FAIL** | pass |
| S3 (`credentials = null`) | **FAIL** | pass |

The failure, from the S3 block against `main`:

```
Error: Attempt to get attribute from null value

  on ../modules/data-source/variables.tf line 117, in variable "credentials":
 117:       var.credentials.type != "CREDENTIAL_PAIR",
    ├────────────────
    │ var.credentials is null

This value is null, so it does not have any attributes.
```

— repeated for each of the six attribute accesses across the three rules. The README HCL itself
needed no changes; it was correct and the module was wrong.

## Still failing

Nothing. All 8 `modules/*` and both `examples/*` dirs pass fmt + init + validate, and all three
`modules/data-source/README.md` example blocks now validate.

## Verification

- `terraform fmt -check`, `terraform init -backend=false`, `terraform validate` in all 8 `modules/*`
  and both `examples/*` dirs, before and after, with `.terraform` / `.terraform.lock.hcl` removed
  between dirs.
- `terraform fmt -recursive -check .` at the repo root.
- All three README example blocks proved in scratch roots as described above, against both `main`
  (via a detached worktree at `origin/main`) and this branch, to show the before/after difference.
- Not verified: no `terraform plan`/`apply` was run, so nothing is checked against the real
  QuickSight API — only against the module's declared variable types and validation rules. In
  particular, whether AWS itself accepts a `S3`/`ATHENA` data source with no credentials block is
  taken from the module's own documentation, not tested.
